### PR TITLE
Glitchサーバーに画像を送信できるようにする#3

### DIFF
--- a/ImageWebSocket.xcodeproj/project.pbxproj
+++ b/ImageWebSocket.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				227491A12B6794CA00B8FC3C /* ImageWebSocketApp.swift */,
-				227491B22B67A90200B8FC3C /* WebSocket */,
+				227491B02B67A8DE00B8FC3C /* WebSocketClient.swift */,
 				227491B32B6BA24300B8FC3C /* View */,
 				227491A52B6794CC00B8FC3C /* Assets.xcassets */,
 				227491A72B6794CC00B8FC3C /* ImageWebSocket.entitlements */,
@@ -70,14 +70,6 @@
 				227491A92B6794CC00B8FC3C /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		227491B22B67A90200B8FC3C /* WebSocket */ = {
-			isa = PBXGroup;
-			children = (
-				227491B02B67A8DE00B8FC3C /* WebSocketClient.swift */,
-			);
-			path = WebSocket;
 			sourceTree = "<group>";
 		};
 		227491B32B6BA24300B8FC3C /* View */ = {

--- a/ImageWebSocket/View/ContentView.swift
+++ b/ImageWebSocket/View/ContentView.swift
@@ -11,6 +11,7 @@ import PhotosUI
 struct ContentView: View {
     @ObservedObject var client: WebSocketClient
     @State private var selectedPhoto: PhotosPickerItem? = nil
+    @State var selectedImage: UIImage?
 
     init(){
         client = WebSocketClient()
@@ -47,7 +48,13 @@ struct ContentView: View {
                     Text("送る画像を選んでください")
                         .font(.title)
                 }
-            )
+            ).onChange(of: selectedPhoto){oldValue, pickedItem in
+                Task {
+                    guard let imageData = try await pickedItem?.loadTransferable(type: Data.self) else {return}
+                    guard let uiImage = UIImage(data: imageData) else {return}
+                    selectedImage = uiImage
+                }
+            }
             Spacer()
             Text(" ↓ Received Image")
                 .font(.title)

--- a/ImageWebSocket/View/ContentView.swift
+++ b/ImageWebSocket/View/ContentView.swift
@@ -11,8 +11,8 @@ import PhotosUI
 struct ContentView: View {
     @ObservedObject var client: WebSocketClient
     @State private var selectedPhoto: PhotosPickerItem? = nil
-    @State var selectedImage: UIImage?
-
+    @State var tmpImage: UIImage? = nil
+    
     init(){
         client = WebSocketClient()
         client.setup(url: "wss://websocket-image-server-toman.glitch.me")
@@ -23,11 +23,7 @@ struct ContentView: View {
             Spacer()
             // space to show recieve from server.
             if client.isConnected{
-                List{
-                    ForEach(client.messages, id: \.self){message in
-                        Text(message)
-                    }
-                }
+                Text("接続済み")
             }else {
                 Text("接続中")
             }
@@ -49,19 +45,41 @@ struct ContentView: View {
                         .font(.title)
                 }
             ).onChange(of: selectedPhoto){oldValue, pickedItem in
+                
                 Task {
+                    // PickedItem → UIImageに変換
                     guard let imageData = try await pickedItem?.loadTransferable(type: Data.self) else {return}
                     guard let uiImage = UIImage(data: imageData) else {return}
-                    selectedImage = uiImage
+                    
+                    // UIImage→Base64に変換
+                    guard let sendString = convertImageToBase64(uiImage) else {
+                        print("can't convert UIImage to Base64")
+                        return
+                    }
+                    guard let compressionImage = convertBase64ToImage(sendString) else {return}
+                    tmpImage = compressionImage
+                    
+//                    client.send(sendString)
                 }
+                
+                
+                
             }
             Spacer()
             Text(" ↓ Received Image")
                 .font(.title)
-            Image("SampleImg")
-                .resizable()
-                .scaledToFit()
-                .padding(.horizontal)
+            if tmpImage != nil {
+                Image(uiImage: tmpImage!)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(.horizontal)
+            }else{
+                Image("SampleImg")
+                    .resizable()
+                    .scaledToFit()
+                    .padding(.horizontal)
+            }
+            
             Spacer()
         }
         .padding()
@@ -71,6 +89,18 @@ struct ContentView: View {
         .onDisappear(){
             client.disconnect()
         }
+    }
+    
+    // UIImage→Base64に変換するメソッド
+    private func convertImageToBase64(_ image: UIImage) -> String? {
+        guard let imageData = image.jpegData(compressionQuality: 0.3) else { return nil }
+        return imageData.base64EncodedString()
+    }
+    
+    // Base64→UIImageに変換するメソッド
+    private func convertBase64ToImage(_ base64String: String) -> UIImage? {
+        guard let imageData = Data(base64Encoded: base64String) else { return nil }
+        return UIImage(data: imageData)
     }
 }
 

--- a/ImageWebSocket/View/ContentView.swift
+++ b/ImageWebSocket/View/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @ObservedObject var client: WebSocketClient
     @State private var selectedPhoto: PhotosPickerItem? = nil
     @State var tmpImage: UIImage? = nil
+    @State var quality: CGFloat = 0.1
     
     init(){
         client = WebSocketClient()
@@ -21,20 +22,13 @@ struct ContentView: View {
     var body: some View {
         VStack {
             Spacer()
-            // space to show recieve from server.
+            // space to show state of connection
             if client.isConnected{
                 Text("接続済み")
             }else {
                 Text("接続中")
             }
             
-            // send button
-            Button(action: {
-                client.send("test")
-            }, label: {
-                Text("aと送る")
-                    .font(.title)
-            })
             Spacer()
             
             // photo picker
@@ -52,14 +46,9 @@ struct ContentView: View {
                     guard let uiImage = UIImage(data: imageData) else {return}
                     
                     // UIImage→Base64に変換
-                    guard let sendString = convertImageToBase64(uiImage) else {
-                        print("can't convert UIImage to Base64")
-                        return
-                    }
-                    guard let compressionImage = convertBase64ToImage(sendString) else {return}
-                    tmpImage = compressionImage
-                    
-//                    client.send(sendString)
+                    guard let sendString = convertImageToBase64(uiImage, quality) else {return}
+
+                    client.send(sendString)
                 }
                 
                 
@@ -92,8 +81,9 @@ struct ContentView: View {
     }
     
     // UIImage→Base64に変換するメソッド
-    private func convertImageToBase64(_ image: UIImage) -> String? {
-        guard let imageData = image.jpegData(compressionQuality: 0.3) else { return nil }
+    private func convertImageToBase64(_ image: UIImage, _ compressionQuality: CGFloat) -> String? {
+        print(compressionQuality)
+        guard let imageData = image.jpegData(compressionQuality: compressionQuality) else { return nil }
         return imageData.base64EncodedString()
     }
     

--- a/ImageWebSocket/WebSocketClient.swift
+++ b/ImageWebSocket/WebSocketClient.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 class WebSocketClient: NSObject, ObservableObject {
     


### PR DESCRIPTION
#3 
## 主要な変更点
1. PhotoPickerからUIImageを選択
2. Jpegで圧縮
3. Base64に変換
4. Glitchサーバーに送信

## その他の変更点
- 受信した文字列を表示するスペースを削除した
## 対応範囲外
- 送受信速度のパフォーマンス向上